### PR TITLE
Brace highlighting and autocompleting

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <id>org.broadinstitute.winstanley</id>
   <name>Winstanley WDL</name>
-  <version>0.1.7-SNAPSHOT</version>
+  <version>0.1.8-SNAPSHOT</version>
   <vendor email="workflow-description-language@googlegroups.com">WDL at Broad Institute</vendor>
 
   <description><![CDATA[
@@ -11,6 +11,8 @@
     ]]></description>
 
   <change-notes><![CDATA[
+  0.1.8:
+    - Added brace matching support.
   0.1.7:
     - Added support for if/then/else expression.
     - Added support for "default=" and "true= false=" sections in command blocks.
@@ -28,6 +30,7 @@
     <fileTypeFactory implementation="winstanley.WdlFileTypeFactory"/>
     <lang.parserDefinition language="wdl" implementationClass="winstanley.WdlParserDefinition"/>
     <lang.syntaxHighlighterFactory language="wdl" implementationClass="winstanley.WdlSyntaxHighlighterFactory"/>
+    <lang.braceMatcher language="wdl" implementationClass="winstanley.WdlBraceMatcher"/>
     <colorSettingsPage implementation="winstanley.WdlColorSettingsPage"/>
   </extensions>
 

--- a/src/winstanley/WdlBraceMatcher.scala
+++ b/src/winstanley/WdlBraceMatcher.scala
@@ -1,0 +1,66 @@
+package winstanley
+
+import com.intellij.lang.{BracePair, PairedBraceMatcher}
+import com.intellij.psi.PsiFile
+import com.intellij.psi.tree.IElementType
+import winstanley.psi.WdlTypes
+
+/**
+  * Provides brace-matching support in WDL by enumerating the types of braces that can be logically
+  * considered as opening and closing each other.
+  *
+  * How to implement this is not especially well documented but this is based on this question:
+  * https://intellij-support.jetbrains.com/hc/en-us/community/posts/115000055450-How-to-make-my-plugin-to-highlight-a-matching-parenthesis-in-the-editor-of-a-language
+  *
+  * And this one:
+  * https://intellij-support.jetbrains.com/hc/en-us/community/posts/115000393430-Auto-closing-braces-in-a-custom-language-BraceMatcher-not-working
+  *
+  * And on the PairedBraceMatcher javadoc comments:
+  * https://github.com/JetBrains/intellij-community/blob/master/platform/lang-api/src/com/intellij/lang/PairedBraceMatcher.java
+  *
+  * And on the BracePair javadoc comments:
+  * https://github.com/JetBrains/intellij-community/blob/master/platform/lang-api/src/com/intellij/lang/BracePair.java
+  *
+  * It's pretty logical: we list the pairs of tokens that can open and close each other, and intellij will auto-insert the
+  * closer when we type the opener, and highlight them together (having worked out any nesting too).
+  */
+class WdlBraceMatcher extends PairedBraceMatcher {
+  /**
+    * Below text copied from PairedBraceMatcher. We choose the "just return true" route...
+    *
+    * Returns true if paired rbrace should be inserted after lbrace of given type when lbrace is encountered before contextType token.
+    * It is safe to always return true, then paired brace will be inserted anyway.
+    * @param lbraceType lbrace for which information is queried
+    * @param contextType token type that follows lbrace
+    * @return true / false as described
+    */
+  override def isPairedBracesAllowedBeforeType(lbraceType: IElementType, contextType: IElementType): Boolean = true
+
+  /**
+    * Below text copied from PairedBraceMatcher...
+    *
+    * Returns the array of definitions for brace pairs that need to be matched when
+    * editing code in the language.
+    *
+    * @return the array of brace pair definitions.
+    */
+  override def getPairs: Array[BracePair] = Array(
+    new BracePair(WdlTypes.COMMAND_VAR_OPENER, WdlTypes.RBRACE, false),
+    new BracePair(WdlTypes.LPAREN, WdlTypes.RPAREN, false),
+    new BracePair(WdlTypes.LBRACE, WdlTypes.RBRACE, true),
+    new BracePair(WdlTypes.LSQUARE, WdlTypes.RSQUARE, false),
+    new BracePair(WdlTypes.COMMAND_DELIMITER_OPEN, WdlTypes.COMMAND_DELIMITER_CLOSE, true)
+  )
+
+  /**
+    * Below text copied from PairedBraceMatcher. I chose to ignore this and just return the input. Seems to work fine...
+    *
+    * Returns the start offset of the code construct which owns the opening structural brace at the specified offset. For example,
+    * if the opening brace belongs to an 'if' statement, returns the start offset of the 'if' statement.
+    *
+    * @param file the file in which brace matching is performed.
+    * @param openingBraceOffset the offset of an opening structural brace.
+    * @return the offset of corresponding code construct, or the same offset if not defined.
+    */
+  override def getCodeConstructStart(file: PsiFile, openingBraceOffset: Int): Int = openingBraceOffset
+}


### PR DESCRIPTION
Should go in after #13 since that update was already pushed to JetBrains.

Enables brace highlighting and autocompleting. Eg type a `{` and a `}` is added for you. And if you hover over a brace, its counterpart is highlighted (see examples below).

![screen shot 2017-09-20 at 5 53 26 pm](https://user-images.githubusercontent.com/13006282/30669644-144ce99c-9e2d-11e7-8f7c-bd124229e7b4.png)
![screen shot 2017-09-20 at 5 53 47 pm](https://user-images.githubusercontent.com/13006282/30669651-1a4571de-9e2d-11e7-8dc6-469d9b72a4c9.png)
