### PR TITLE
Collapsible blocks in the WDL editor

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -14,6 +14,7 @@
   0.1.8:
     - Added brace matching support.
     - Added auto-commenting/uncommenting
+    - Added foldable sections in the WDL editor.
   0.1.7:
     - Added support for if/then/else expression.
     - Added support for "default=" and "true= false=" sections in command blocks.
@@ -33,6 +34,7 @@
     <lang.syntaxHighlighterFactory language="wdl" implementationClass="winstanley.WdlSyntaxHighlighterFactory"/>
     <lang.braceMatcher language="wdl" implementationClass="winstanley.WdlBraceMatcher"/>
     <lang.commenter language="wdl" implementationClass="winstanley.WdlCommenter"/>
+    <lang.foldingBuilder language="wdl" implementationClass="winstanley.WdlFoldingBuilder"/>
     <colorSettingsPage implementation="winstanley.WdlColorSettingsPage"/>
   </extensions>
 

--- a/src/winstanley/WdlFoldingBuilder.scala
+++ b/src/winstanley/WdlFoldingBuilder.scala
@@ -1,0 +1,20 @@
+package winstanley
+
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.{FoldingBuilderEx, FoldingDescriptor}
+import com.intellij.openapi.editor.Document
+import com.intellij.psi.PsiElement
+import winstanley.structure.WdlDocumentUtils._
+
+class WdlFoldingBuilder extends FoldingBuilderEx {
+
+  private def foldingRegions(psiElement: PsiElement): Array[FoldingDescriptor] = {
+    (psiElement.getChildren flatMap foldingRegions) ++ (psiElement.contentRange map { new FoldingDescriptor(psiElement.getNode, _)})
+  }
+
+  override def buildFoldRegions(root: PsiElement, document: Document, quick: Boolean): Array[FoldingDescriptor] = foldingRegions(root)
+
+  override def getPlaceholderText(astNode: ASTNode): String = " ... "
+
+  override def isCollapsedByDefault(astNode: ASTNode): Boolean = false
+}

--- a/src/winstanley/structure/WdlDocumentUtils.scala
+++ b/src/winstanley/structure/WdlDocumentUtils.scala
@@ -1,0 +1,46 @@
+package winstanley.structure
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.tree.IElementType
+import winstanley.psi._
+
+object WdlDocumentUtils {
+  implicit final class EnhancedPsiElement(val psiElement: PsiElement) extends AnyVal {
+    def childTaskBlocks: Set[WdlTaskBlock] = (psiElement.getChildren collect {
+      case t: WdlTaskBlock => t
+    }).toSet
+
+    def childWorkflowBlocks: Set[WdlWorkflowBlock] = (psiElement.getChildren collect {
+      case w: WdlWorkflowBlock => w
+    }).toSet
+
+    def contentRange: Option[TextRange] = psiElement match {
+      case _: WdlTaskBlock | _: WdlWorkflowBlock | _: WdlTaskOutputs | _: WdlWfOutputs | _: WdlCallBlock | _: WdlScatterBlock | _: WdlIfStmt =>
+        interBraceContentRange(psiElement, WdlTypes.LBRACE, WdlTypes.RBRACE)
+      case wcb: WdlCommandBlock => interBraceContentRange(wcb, WdlTypes.COMMAND_DELIMITER_OPEN, WdlTypes.COMMAND_DELIMITER_CLOSE)
+      case _: WdlRuntimeBlock | _: WdlParameterMetaBlock =>
+        mapContainingContentRange(psiElement)
+      case _ => None
+    }
+
+    private def mapContainingContentRange(psiElement: PsiElement): Option[TextRange] = psiElement.getChildren.collectFirst {
+      case m: WdlMap => interBraceContentRange(m, WdlTypes.LBRACE, WdlTypes.RBRACE)
+    }.flatten
+
+    private def interBraceContentRange(psiElement: PsiElement, ltype: IElementType, rtype: IElementType): Option[TextRange] = {
+      for {
+        lbrace <- Option(psiElement.getNode.findChildByType(ltype))
+        rbrace <- Option(psiElement.getNode.findChildByType(rtype))
+      } yield new TextRange(lbrace.getTextRange.getStartOffset + 1, rbrace.getTextRange.getEndOffset - 1)
+    }
+  }
+
+  implicit final class EnhancedWdlTaskBlock(val wdlTaskBlock: WdlTaskBlock) extends AnyVal {
+    def taskName: String = wdlTaskBlock.getNode.findChildByType(winstanley.psi.WdlTypes.TASK_IDENTIFIER_DECL).getText
+  }
+
+  implicit final class EnhancedWdlWorkflowBlock(val wdlWorkflowBlock: WdlWorkflowBlock) extends AnyVal {
+    def workflowName: String = wdlWorkflowBlock.getNode.findChildByType(winstanley.psi.WdlTypes.WORKFLOW_IDENTIFIER_DECL).getText
+  }
+}


### PR DESCRIPTION
Gives up collapsible regions, eg:

![screen shot 2017-09-21 at 6 40 43 pm](https://user-images.githubusercontent.com/13006282/30721993-a5e588ee-9efc-11e7-98b7-42c49423e2d7.png)
