### PR TITLE
Detect undefined values

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -13,8 +13,9 @@
   <change-notes><![CDATA[
   0.1.8:
     - Added brace matching support.
-    - Added auto-commenting/uncommenting
+    - Added auto-commenting/uncommenting.
     - Added foldable sections in the WDL editor.
+    - Added undeclared variable detection.
   0.1.7:
     - Added support for if/then/else expression.
     - Added support for "default=" and "true= false=" sections in command blocks.
@@ -36,6 +37,7 @@
     <lang.commenter language="wdl" implementationClass="winstanley.WdlCommenter"/>
     <lang.foldingBuilder language="wdl" implementationClass="winstanley.WdlFoldingBuilder"/>
     <colorSettingsPage implementation="winstanley.WdlColorSettingsPage"/>
+    <annotator language="wdl" implementationClass="winstanley.WdlAnnotator"/>
   </extensions>
 
   <actions>

--- a/src/winstanley/WdlAnnotator.scala
+++ b/src/winstanley/WdlAnnotator.scala
@@ -1,0 +1,31 @@
+package winstanley
+
+import com.intellij.lang.annotation.{AnnotationHolder, Annotator}
+import com.intellij.psi.PsiElement
+import winstanley.psi.WdlValue
+import winstanley.structure.WdlImplicits._
+
+
+class WdlAnnotator extends Annotator {
+  override def annotate(psiElement: PsiElement, annotationHolder: AnnotationHolder): Unit = psiElement match {
+    case value: WdlValue =>
+
+      // If this value is an identifier, make sure that it's been declared somewhere (either in a declaration or in a scatter)
+      value.asIdentifierNode foreach { identifier =>
+        val declarationNames = value.findDeclarationsAvailableInScope.map(_.declaredValueName) collect { case Some(d) => d }
+
+        val scatterVariableName = for {
+          outerscatter <- value.findContainingScatter
+          scatterVariable <- outerscatter.getIdentifierNode
+        } yield scatterVariable.getText
+
+        val availableValueNames = declarationNames ++ scatterVariableName
+
+        val identifierText = identifier.getText
+        if (!availableValueNames.contains(identifierText)) {
+          annotationHolder.createErrorAnnotation(identifier.getTextRange, s"No declaration found for '${identifier.getText}'")
+        }
+      }
+    case _ => ()
+  }
+}

--- a/src/winstanley/WdlFoldingBuilder.scala
+++ b/src/winstanley/WdlFoldingBuilder.scala
@@ -4,7 +4,7 @@ import com.intellij.lang.ASTNode
 import com.intellij.lang.folding.{FoldingBuilderEx, FoldingDescriptor}
 import com.intellij.openapi.editor.Document
 import com.intellij.psi.PsiElement
-import winstanley.structure.WdlDocumentUtils._
+import winstanley.structure.WdlImplicits._
 
 class WdlFoldingBuilder extends FoldingBuilderEx {
 


### PR DESCRIPTION
Lets the intelliJ plugin detect and error-highlight values which haven't been declared.

eg:
![screen shot 2017-09-22 at 2 07 54 pm](https://user-images.githubusercontent.com/13006282/30758236-806551d2-9f9f-11e7-9e07-c34184e4ef49.png)
