### PR TITLE
Tactical fix to allow imported tasks

### DIFF
--- a/src/winstanley/WdlAnnotator.scala
+++ b/src/winstanley/WdlAnnotator.scala
@@ -23,7 +23,7 @@ class WdlAnnotator extends Annotator {
         }
       }
     case value: WdlCallableLookup =>
-      // TODO (Issue 63): Work out a better way to verify that imports exist and (if local) that files inside them exist.
+      // TODO (Issue 63): Work out a better way to verify that imports exist and (if local?) that an appropriate task/workflow inside them exist.
       // For now to avoid error highlights, I'll just suppress errors for things that look like FQNs
       if (value.getFullyQualifiedName.getNode.getChildren(null).length == 1) {
         value.getFullyQualifiedName.getIdentifierNode foreach { identifier =>

--- a/src/winstanley/WdlAnnotator.scala
+++ b/src/winstanley/WdlAnnotator.scala
@@ -23,15 +23,19 @@ class WdlAnnotator extends Annotator {
         }
       }
     case value: WdlCallableLookup =>
+      // TODO (Issue 63): Work out a better way to verify that imports exist and (if local) that files inside them exist.
+      // For now to avoid error highlights, I'll just suppress errors for things that look like FQNs
+      if (value.getFullyQualifiedName.getNode.getChildren(null).length == 1) {
+        value.getFullyQualifiedName.getIdentifierNode foreach { identifier =>
+          val identifierText = identifier.getText
+          val taskNames = value.findTasksInScope.flatMap(_.declaredValueName)
 
-      value.getFullyQualifiedName.getIdentifierNode foreach { identifier =>
-        val identifierText = identifier.getText
-        val taskNames = value.findTasksInScope.flatMap(_.declaredValueName)
-
-        if (!taskNames.contains(identifierText)) {
-          annotationHolder.createErrorAnnotation(identifier.getTextRange, s"No task declaration found for '${identifier.getText}'")
+          if (!taskNames.contains(identifierText)) {
+            annotationHolder.createErrorAnnotation(identifier.getTextRange, s"No task declaration found for '${identifier.getText}'")
+          }
         }
-      }
+      } else
+        ()
     case _ => ()
   }
 }

--- a/tests/testData/annotation/import_sub_wf.wdl
+++ b/tests/testData/annotation/import_sub_wf.wdl
@@ -1,0 +1,5 @@
+import "x.wdl" as x_wdl
+
+workflow foo {
+  call x_wdl.sub_wf
+}

--- a/tests/winstanley/AnnotationSpec.scala
+++ b/tests/winstanley/AnnotationSpec.scala
@@ -20,12 +20,10 @@ class AnnotationSpec extends LightCodeInsightFixtureTestCase {
   }
 
   def testOutputMissingDeclaration(): Unit = annotationTest("output_missing_declaration.wdl")
-
   def testMissingTaskDeclaration(): Unit = annotationTest("missing_task_declaration.wdl")
-
   def testMissingAliasDeclaration(): Unit = annotationTest("missing_alias_declaration.wdl")
-
   def testLookupNotPointingToAliasDeclaration(): Unit = annotationTest("value_lookup_not_pointing_to_alias_declaration.wdl")
+  def testImportedTaskNotAnnotated(): Unit = annotationTest("import_sub_wf.wdl")
 
   private def annotationTest(path: String): Unit = {
     myFixture.configureByFile(path)


### PR DESCRIPTION
This is a tactical PR to allow us to release the new go-to-definition changes without false error highlights on imports.

I've added ticket #63 to remind us to do the real validation on imports.