### PR TITLE
Fix command/placeholder interaction

### DIFF
--- a/src/winstanley/Wdl.flex
+++ b/src/winstanley/Wdl.flex
@@ -122,7 +122,7 @@ STRUCT="struct"
 <COMMAND2> {TRIPLE_ANGLE_CLOSE}                        { yybegin(YYINITIAL); return WdlTypes.COMMAND_DELIMITER_CLOSE; }
 <COMMAND1> {DEPRECATED_PLACEHOLDER_OPENER}             { yybegin(COMMAND1_VAR); return WdlTypes.COMMAND_VAR_OPENER; }
 <COMMAND1> {NEW_PLACEHOLDER_OPENER}                    { yybegin(COMMAND1_VAR); return WdlTypes.COMMAND_VAR_OPENER; }
-<COMMAND2> {DEPRECATED_PLACEHOLDER_OPENER}             { if (wdlVersion == "draft-2") { yybegin(COMMAND1_VAR); return WdlTypes.COMMAND_VAR_OPENER; } else { return WdlTypes.COMMAND_CHAR; } }
+<COMMAND2> {DEPRECATED_PLACEHOLDER_OPENER}             { if (wdlVersion == "draft-2") { yybegin(COMMAND2_VAR); return WdlTypes.COMMAND_VAR_OPENER; } else { return WdlTypes.COMMAND_CHAR; } }
 <COMMAND2> {NEW_PLACEHOLDER_OPENER}                    { yybegin(COMMAND2_VAR); return WdlTypes.COMMAND_VAR_OPENER; }
 <COMMAND1_VAR> {RBRACE}                                { yybegin(COMMAND1); return WdlTypes.RBRACE; }
 <COMMAND2_VAR> {RBRACE}                                { yybegin(COMMAND2); return WdlTypes.RBRACE; }


### PR DESCRIPTION
Match on `>>>` instead of `}` when closing a `<<<` command that includes a deprecated placeholder opener `${` (the new placeholder opener `~{` works fine) 

#74