### PR TITLE
0.4 release; update WDL repo to OpenWDL

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -12,7 +12,7 @@
 
   <change-notes><![CDATA[
   0.4:
-    - Highlight missing, mis-named, and extraneous inputs at call sites (WDL 1.0 only)
+    - Highlight missing, misspelled, and extraneous inputs at call sites (WDL 1.0 only)
   0.3.3:
     - Fixed an issue that caused variables named "version" to be incorrectly flagged as errors
   0.3.2:

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,16 +1,18 @@
 <idea-plugin>
   <id>org.broadinstitute.winstanley</id>
   <name>Winstanley WDL</name>
-  <version>0.3.3</version>
+  <version>0.4</version>
   <vendor email="workflow-description-language@googlegroups.com">WDL at Broad Institute</vendor>
 
   <description><![CDATA[
       Winstanley provides WDL language support to the IntelliJ IDEA IDE.
-      For the WDL language specification, see https://github.com/broadinstitute/wdl.
+      For the WDL language specification, see https://github.com/openwdl/wdl.
       For a workflow engine runner which supports WDL, see https://github.com/broadinstitute/cromwell.
     ]]></description>
 
   <change-notes><![CDATA[
+  0.4:
+    - Highlight missing, mis-named, and extraneous inputs at call sites (WDL 1.0 only)
   0.3.3:
     - Fixed an issue that caused variables named "version" to be incorrectly flagged as errors
   0.3.2:


### PR DESCRIPTION
I had sent Dan Moran an early build of the call input checking branch and he experienced crashes on a particular WDL.

I loaded up that WDL in `develop` and it works fine, so I'm calling this fixed.